### PR TITLE
Fix Second issues

### DIFF
--- a/ChatClient/MainWindow.xaml.cs
+++ b/ChatClient/MainWindow.xaml.cs
@@ -113,7 +113,7 @@ namespace RedesignedChatClient
                     {
                         _server.SendDirectMessage(message, _username, recipient);
 
-                        AddPrivateMessageToUI(_username, recipient, message, isSender: true);
+                        DisplayPrivateMessage(_username, recipient, message, isSender: true);
 
                         MessageTextBox_Private.Clear();
                     }
@@ -159,11 +159,13 @@ namespace RedesignedChatClient
         // Метод для отримання приватного повідомлення
         public void ReceiveDirectMessage(string message, string sender)
         {
-            Dispatcher.Invoke(() =>
-            {
-                AddPrivateMessageToUI(sender, _username, message, isSender: false);
-                Console.WriteLine($"Отримано приватне повідомлення від {sender}: {message}");
-            });
+            DisplayPrivateMessage(sender, _username, message, isSender: false);
+        }
+
+        // Метод для відображення приватного повідомлення
+        private void DisplayPrivateMessage(string sender, string recipient, string message, bool isSender)
+        {
+            Dispatcher.Invoke(() => AddPrivateMessageToUI(sender, recipient, message, isSender));
         }
 
         // Оновлення списку онлайн користувачів

--- a/ChatLibrary/ChatService.cs
+++ b/ChatLibrary/ChatService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.ServiceModel;
@@ -9,35 +10,29 @@ namespace RedesignedChatLibrary
     [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Reentrant)]
     public class ChatServer : IChatServer
     {
-        private readonly Dictionary<string, IChatClient> _clients = new Dictionary<string, IChatClient>();
-        private readonly object _lock = new object();
+        private readonly ConcurrentDictionary<string, IChatClient> _clients = new ConcurrentDictionary<string, IChatClient>();
 
         // Реєстрація користувача
         public bool RegisterUser(string username)
         {
             try
             {
-                lock (_lock)
+                var callback = OperationContext.Current.GetCallbackChannel<IChatClient>();
+                if (callback == null)
                 {
-                    if (_clients.ContainsKey(username))
-                    {
-                        return false; 
-                    }
-
-                    var callback = OperationContext.Current.GetCallbackChannel<IChatClient>();
-                    if (callback == null)
-                    {
-                        Console.WriteLine("Callback channel is null!");
-                        return false;
-                    }
-
-                    _clients[username] = callback;
-                    Console.WriteLine($"User {username} connected.");
-
-                    BroadcastUserListAsync();
-                    BroadcastMessageAsync("System", $"{username} has joined the chat.");
-                    return true;
+                    Console.WriteLine("Callback channel is null!");
+                    return false;
                 }
+
+                if (!_clients.TryAdd(username, callback))
+                {
+                    return false;
+                }
+
+                Console.WriteLine($"User {username} connected.");
+                BroadcastUserListAsync();
+                BroadcastMessageAsync("System", $"{username} has joined the chat.");
+                return true;
             }
             catch (Exception ex)
             {
@@ -50,11 +45,8 @@ namespace RedesignedChatLibrary
         private async Task BroadcastUserListAsync()
         {
             var onlineUsers = _clients.Keys.ToList();
-            var tasks = new List<Task>();
-
-            foreach (var client in _clients.Values)
-            {
-                tasks.Add(Task.Run(() =>
+            var tasks = _clients.Values.Select(client =>
+                Task.Run(() =>
                 {
                     try
                     {
@@ -64,8 +56,7 @@ namespace RedesignedChatLibrary
                     {
                         Console.WriteLine($"Error updating user list: {ex.Message}");
                     }
-                }));
-            }
+                })).ToList();
 
             await Task.WhenAll(tasks);
         }
@@ -73,14 +64,11 @@ namespace RedesignedChatLibrary
         // Видалення користувача
         public void RemoveUser(string username)
         {
-            lock (_lock)
+            if (_clients.TryRemove(username, out _))
             {
-                if (_clients.Remove(username))
-                {
-                    Console.WriteLine($"User {username} disconnected.");
-                    BroadcastUserListAsync();
-                    BroadcastMessageAsync("System", $"{username} has left the chat.");
-                }
+                Console.WriteLine($"User {username} disconnected.");
+                BroadcastUserListAsync();
+                BroadcastMessageAsync("System", $"{username} has left the chat.");
             }
         }
 
@@ -93,68 +81,54 @@ namespace RedesignedChatLibrary
         // Відправка приватного повідомлення
         public void SendDirectMessage(string message, string sender, string recipient)
         {
-            lock (_lock)
+            if (_clients.TryGetValue(recipient, out var recipientClient))
             {
-                if (_clients.TryGetValue(recipient, out var recipientClient))
+                try
                 {
-                    try
-                    {
-                        recipientClient.ReceiveDirectMessage(message, sender);
-                        Console.WriteLine($"Приватне повідомлення від {sender} до {recipient}: {message}");
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Помилка відправки повідомлення до {recipient}: {ex.Message}");
-                    }
+                    recipientClient.ReceiveDirectMessage(message, sender);
+                    Console.WriteLine($"Приватне повідомлення від {sender} до {recipient}: {message}");
                 }
-                else
+                catch (Exception ex)
                 {
-                    Console.WriteLine($"Отримувач {recipient} не знайдений.");
+                    Console.WriteLine($"Помилка відправки повідомлення до {recipient}: {ex.Message}");
                 }
+            }
+            else
+            {
+                Console.WriteLine($"Отримувач {recipient} не знайдений.");
             }
         }
 
         // Відправка повідомлення всім користувачам
         private async Task BroadcastMessageAsync(string sender, string message)
         {
-            var disconnectedUsers = new List<string>();
-            var tasks = new List<Task>();
-
-            foreach (var user in _clients)
-            {
-                tasks.Add(Task.Run(() =>
+            var disconnectedUsers = new ConcurrentBag<string>();
+            var tasks = _clients.Select(user =>
+                Task.Run(() =>
                 {
-                try
-                {
-                    user.Value.ReceiveMessage(message, sender);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error sending message to {user.Key}: {ex.Message}");
-                        lock (_lock)
-                        {
-                            disconnectedUsers.Add(user.Key);
-                        }
+                    try
+                    {
+                        user.Value.ReceiveMessage(message, sender);
                     }
-                }));
-            }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Error sending message to {user.Key}: {ex.Message}");
+                        disconnectedUsers.Add(user.Key);
+                    }
+                })).ToList();
 
             await Task.WhenAll(tasks);
 
-            lock (_lock)
+            foreach (var user in disconnectedUsers)
             {
-                foreach (var user in disconnectedUsers)
-                {
-                    _clients.Remove(user);
-                    Console.WriteLine($"User {user} has been disconnected due to an error.");
-                }
+                _clients.TryRemove(user, out _);
+                Console.WriteLine($"User {user} has been disconnected due to an error.");
             }
 
-            if (disconnectedUsers.Any())
+            if (!disconnectedUsers.IsEmpty)
             {
                 await BroadcastUserListAsync();
             }
         }
     }
 }
-


### PR DESCRIPTION
### **Description of Changes:**  
- Replaced `Dictionary<string, IChatClient>` with `ConcurrentDictionary<string, IChatClient>` for thread-safe operations.  
- Removed all `lock` statements previously used for synchronizing access to `_clients`.  
- Used `TryAdd`, `TryRemove`, and `TryGetValue` instead of manual locking.  
- Optimized `BroadcastMessageAsync` by using `ConcurrentBag<string>` to collect disconnected users.  
- Improved performance and scalability by eliminating unnecessary thread blocking.